### PR TITLE
Fix light colors on profile page

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -980,4 +980,9 @@
     .UnderlineNav .Counter {
         color: #aeb9c3;
     }
+    :root{
+        --color-calendar-graph-day-bg:#24292e;
+        --color-bg-primary: #1f2327;
+        --color-text-primary: #d8e2ec;
+    }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -988,5 +988,6 @@
         --color-bg-canvas:#24292e;
         --color-box-bg-info:#24292e;
         --color-underlinenav-text-hover: #d8e2ec;
+        --color-branch-name-link-bg:#45474a;
     }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -987,5 +987,6 @@
         --color-previewable-comment-form-bg:#24292e;
         --color-bg-canvas:#24292e;
         --color-box-bg-info:#24292e;
+        --color-underlinenav-text-hover: #d8e2ec;
     }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -985,5 +985,6 @@
         --color-bg-primary: #1f2327;
         --color-text-primary: #d8e2ec;
         --color-previewable-comment-form-bg:#24292e;
+        --color-bg-canvas:#24292e;
     }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -986,5 +986,6 @@
         --color-text-primary: #d8e2ec;
         --color-previewable-comment-form-bg:#24292e;
         --color-bg-canvas:#24292e;
+        --color-box-bg-info:#24292e;
     }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -984,5 +984,6 @@
         --color-calendar-graph-day-bg:#24292e;
         --color-bg-primary: #1f2327;
         --color-text-primary: #d8e2ec;
+        --color-previewable-comment-form-bg:#24292e;
     }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -989,5 +989,6 @@
         --color-box-bg-info:#24292e;
         --color-underlinenav-text-hover: #d8e2ec;
         --color-branch-name-link-bg:#45474a;
+        --color-box-row-blue-bg: #45474a;
     }
 }


### PR DESCRIPTION
Added some global variables so that the colored squares showing frequency of commits and the text for the recent commits underneath it would look correct in dark mode.,